### PR TITLE
Add context link to header of thread

### DIFF
--- a/src/_data/externalLinkPostTypes.json
+++ b/src/_data/externalLinkPostTypes.json
@@ -1,5 +1,5 @@
 {
   "repost-of": "Repost of",
   "like-of": "Like of",
-  "bookmark-of": "Bookmark of",
+  "bookmark-of": "Bookmark of"
 }

--- a/src/_data/externalLinkPostTypes.json
+++ b/src/_data/externalLinkPostTypes.json
@@ -1,0 +1,5 @@
+{
+  "repost-of": "Repost of",
+  "like-of": "Like of",
+  "bookmark-of": "Bookmark of",
+}

--- a/src/_data/threads.js
+++ b/src/_data/threads.js
@@ -1,3 +1,4 @@
+const externalLinkPostTypes = require('./externalLinkPostTypes.json');
 const postOverrides = require('./postOverrides.json');
 const axios = require('axios');
 const xxhash64 = require('../../xxhash64');
@@ -79,6 +80,13 @@ module.exports = async function () {
             thread.title = post.name;
             thread.posts.push(post);
             thread.parent = post;
+            for (const [property, text] of Object.entries(externalLinkPostTypes)) {
+                const externalLink = post[property];
+                if (externalLink) {
+                    thread.context = { externalLink, text};
+                    break;
+                }
+            }
         } else {
             // Handle the post as a comment on an existing thread
 

--- a/src/_includes/style.html
+++ b/src/_includes/style.html
@@ -106,6 +106,9 @@ color: blue;
 .thread-title{
     padding: 2em 3em 0 3em;
 }
+.thread-title h2{
+    font-size: 16px;
+}
 .thread-post {
     border-bottom: 1px solid #333;
     padding: 2em 3em;

--- a/src/thread-view.html
+++ b/src/thread-view.html
@@ -22,7 +22,7 @@ layout: "base"
             <h2>
                 {{thread.context.text}} <a href="{{thread.context.externalLink}}">{{thread.context.externalLink }}</a>
             </h2>
-        [% endif %}
+        {% endif %}
     </section>
     {% for post in thread.posts reversed %}
         <article class="thread-post">

--- a/src/thread-view.html
+++ b/src/thread-view.html
@@ -18,6 +18,11 @@ layout: "base"
 
     <section class="thread-title">
         <h1>{{thread.title}}</h1>
+        <% if thread.context %>
+            <h2>
+                {{thread.context.text}} <a href="{{thread.context.externalLink}}">{{thread.context.externalLink }}</a>
+            </h2>
+        <% endif %>
     </section>
     {% for post in thread.posts reversed %}
         <article class="thread-post">

--- a/src/thread-view.html
+++ b/src/thread-view.html
@@ -18,11 +18,11 @@ layout: "base"
 
     <section class="thread-title">
         <h1>{{thread.title}}</h1>
-        <% if thread.context %>
+        {% if thread.context %}
             <h2>
                 {{thread.context.text}} <a href="{{thread.context.externalLink}}">{{thread.context.externalLink }}</a>
             </h2>
-        <% endif %>
+        [% endif %}
     </section>
     {% for post in thread.posts reversed %}
         <article class="thread-post">


### PR DESCRIPTION
I configured the post types in `src/_data/externalLinkPostTypes.json` so that other post types (`read-of`, `rsvp-of`, etc) could be added if request.

I have a netlify deploy at https://jovial-panini-f4c738.netlify.app/ if you want to see how it looks.