### PR TITLE
Add microformat classes to enable original post discovery

### DIFF
--- a/src/_data/threads.js
+++ b/src/_data/threads.js
@@ -83,7 +83,7 @@ module.exports = async function () {
             for (const [property, text] of Object.entries(externalLinkPostTypes)) {
                 const externalLink = post[property];
                 if (externalLink) {
-                    thread.context = { externalLink, text};
+                    thread.context = { externalLink, text, microformatClass: `u-${property}` };
                     break;
                 }
             }

--- a/src/thread-view.html
+++ b/src/thread-view.html
@@ -14,32 +14,39 @@ layout: "base"
 }
 ---
 
-<main class="thread-container">
+<main class="thread-container h-entry">
 
     <section class="thread-title">
-        <h1>{{thread.title}}</h1>
+        <h1 class="p-name">{{thread.title}}</h1>
         {% if thread.context %}
             <h2>
-                {{thread.context.text}} <a href="{{thread.context.externalLink}}">{{thread.context.externalLink }}</a>
+                {{thread.context.text}}
+                <a href="{{thread.context.externalLink}}" class="{{thread.context.microformatClass}}">{{thread.context.externalLink }}</a>
             </h2>
         {% endif %}
     </section>
     {% for post in thread.posts reversed %}
-        <article class="thread-post">
+        <article class="thread-post {% unless forloop.first %}u-comment h-entry{% endunless %}">
 
             <section class="post-author">
-                <a href="{{post.author.url}}" title="{{post.author.name}}">
-                    <img src="{{post.author.photo}}" alt="{{post.author.name}}" width="40px" height="40px" class="avatar"><b>{{post.author.name}}</b></a>
+                <span class="h-card">
+                    <a href="{{post.author.url}}" title="{{post.author.name}}" class="u-url">
+                        <img src="{{post.author.photo}}" alt="{{post.author.name}}" width="40px" height="40px" class="avatar u-photo">
+                        <b class="p-name">{{post.author.name}}</b>
+                    </a>
+                </span>
                  -
-                <a href="{{post.wm-source}}" class="post-permalink">
-                    {{ post.published | dayjs }}
+                <a href="{{post.wm-source}}" class="post-permalink u-url u-uid">
+                    <time datetime="{{post.published}}" class="dt-published">
+                        {{ post.published | dayjs }}
+                    </time>
                 </a>
             </section>
 
-            <section class="post-content">
-
+            <section class="post-content e-content">
                 {{post.content.html}}
-                </section>
+            </section>
+
             <section class="post-footer">
                 
                 <details class="post-reply-to">


### PR DESCRIPTION
This PR adds microformat classes to indieforum threads. The main purpose of this is to add `u-url and u-uid` to the canonical links of syndicated posts so that compliant software can use [original post discovery](https://indieweb.org/original-post-discovery) to reply. This means users can reply directly to an indieforums link instead of copying/pasting the canonical links.

[Here's](http://pin13.net/mf2/?url=https%3A%2F%2Fjovial-panini-f4c738.netlify.app%2Fthreads%2Fc1c36e81a755848c.html) an example of one of the parsed threads.